### PR TITLE
fix: complete and verify Windows release packaging

### DIFF
--- a/.github/workflows/desktop-packages.yml
+++ b/.github/workflows/desktop-packages.yml
@@ -84,7 +84,7 @@ jobs:
         run: |
           hdiutil verify release/*.dmg
           unzip -t release/*-mac-universal.zip
-          archs="$(lipo -archs "release/mac-universal/Pi Agent Desktop.app/Contents/MacOS/Pi Agent Desktop")"
+          archs="$(lipo -archs "release/mac-universal/HaJiMi.app/Contents/MacOS/HaJiMi")"
           echo "lipo archs: ${archs}"
           echo "${archs}" | grep -q "x86_64"
           echo "${archs}" | grep -q "arm64"
@@ -107,7 +107,7 @@ jobs:
           name: desktop-linux
           if-no-files-found: error
           path: |
-            release/Pi-Agent-Desktop-*-linux-*.deb
+            release/HaJiMi-*-linux-*.deb
             release/latest-linux.yml
 
       - name: Upload macOS artifacts
@@ -117,10 +117,10 @@ jobs:
           name: desktop-macos
           if-no-files-found: error
           path: |
-            release/Pi-Agent-Desktop-*-mac-universal.dmg
-            release/Pi-Agent-Desktop-*-mac-universal.dmg.blockmap
-            release/Pi-Agent-Desktop-*-mac-universal.zip
-            release/Pi-Agent-Desktop-*-mac-universal.zip.blockmap
+            release/HaJiMi-*-mac-universal.dmg
+            release/HaJiMi-*-mac-universal.dmg.blockmap
+            release/HaJiMi-*-mac-universal.zip
+            release/HaJiMi-*-mac-universal.zip.blockmap
             release/latest-mac.yml
 
   publish:

--- a/.github/workflows/desktop-packages.yml
+++ b/.github/workflows/desktop-packages.yml
@@ -70,6 +70,19 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: gh release download runtime-windows-1.0.0 --pattern "hajimi-runtime-1.0.0-local-test.20260905-win32-x64.tar.gz" --dir runtime/windows/payloads
 
+      - name: Download bundled draw.io
+        if: matrix.pack_id == 'windows'
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release download v28.2.5 --repo jgraph/drawio-desktop --pattern "draw.io-28.2.5-windows.zip" --dir runtime/windows
+          if ($LASTEXITCODE -ne 0) { throw "draw.io download failed" }
+          $archive = "runtime/windows/draw.io-28.2.5-windows.zip"
+          if ((Get-FileHash $archive -Algorithm SHA256).Hash.ToLowerInvariant() -ne "9e40f32765f87c443fce9259e9d0c51eb555b6a733aa929bc5a22b7e1ead4aee") { throw "draw.io checksum mismatch" }
+          Expand-Archive -LiteralPath $archive -DestinationPath runtime/windows/drawio
+          if (!(Test-Path runtime/windows/drawio/draw.io.exe)) { throw "draw.io executable missing" }
+
       - name: Build installer
         env:
           HAJIMI_OFFLINE_RUNTIME: ${{ matrix.pack_id == 'windows' && '1' || '0' }}

--- a/.github/workflows/desktop-packages.yml
+++ b/.github/workflows/desktop-packages.yml
@@ -24,16 +24,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - pack_id: windows
-            runner: windows-latest
-            dist_script: dist
-          - pack_id: linux
-            runner: ubuntu-latest
-            dist_script: dist
-          - pack_id: macos
-            runner: macos-latest
-            dist_script: dist:mac
+        # Official releases currently support the Windows modeling backend.
+        # Manual runs retain cross-platform packaging diagnostics.
+        include: ${{ fromJSON(github.event_name == 'push' && '[{"pack_id":"windows","runner":"windows-latest","dist_script":"dist"}]' || '[{"pack_id":"windows","runner":"windows-latest","dist_script":"dist"},{"pack_id":"linux","runner":"ubuntu-latest","dist_script":"dist"},{"pack_id":"macos","runner":"macos-latest","dist_script":"dist:mac"}]') }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -150,7 +143,7 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          pattern: desktop-*
+          pattern: desktop-windows
           path: dist-artifacts
           merge-multiple: true
 
@@ -166,16 +159,9 @@ jobs:
             dist-artifacts/HaJiMi-Setup-*.exe
             dist-artifacts/HaJiMi-Setup-*.exe.blockmap
             dist-artifacts/latest.yml
-            dist-artifacts/HaJiMi-*-linux-*.deb
-            dist-artifacts/latest-linux.yml
-            dist-artifacts/HaJiMi-*-mac-universal.dmg
-            dist-artifacts/HaJiMi-*-mac-universal.dmg.blockmap
-            dist-artifacts/HaJiMi-*-mac-universal.zip
-            dist-artifacts/HaJiMi-*-mac-universal.zip.blockmap
-            dist-artifacts/latest-mac.yml
           )
-          if [ "${#assets[@]}" -ne 10 ]; then
-            echo "expected 10 release assets, found ${#assets[@]}:"
+          if [ "${#assets[@]}" -ne 3 ]; then
+            echo "expected 3 Windows release assets, found ${#assets[@]}:"
             printf '%s\n' "${assets[@]}"
             ls -la dist-artifacts
             exit 1

--- a/docs/releases/v0.1.1.md
+++ b/docs/releases/v0.1.1.md
@@ -15,6 +15,7 @@
 
 ## 安装提示
 
+- 完整建模流程目前面向 Windows。Linux/macOS 附件仅为桌面应用构建，尚未提供原生建模执行后端，不能作为与 Windows 功能等价的完整建模版本使用。
 - Windows 安装包尚未代码签名，安装时可能出现 SmartScreen 提示。
 - macOS 安装包尚未签名和公证，首次打开时可能出现 Gatekeeper 提示。
 - Linux `.deb` 尚未进行 debsig 签名；应用内更新安装时需要 root 授权，下载完整性由 `latest-linux.yml` 中的 SHA512 校验。

--- a/docs/releases/v0.1.1.md
+++ b/docs/releases/v0.1.1.md
@@ -15,7 +15,5 @@
 
 ## 安装提示
 
-- 完整建模流程目前面向 Windows。Linux/macOS 附件仅为桌面应用构建，尚未提供原生建模执行后端，不能作为与 Windows 功能等价的完整建模版本使用。
+- 本次仅发布 Windows 安装包。Linux/macOS 尚未提供原生建模执行后端，暂不作为完整建模版本发布。
 - Windows 安装包尚未代码签名，安装时可能出现 SmartScreen 提示。
-- macOS 安装包尚未签名和公证，首次打开时可能出现 Gatekeeper 提示。
-- Linux `.deb` 尚未进行 debsig 签名；应用内更新安装时需要 root 授权，下载完整性由 `latest-linux.yml` 中的 SHA512 校验。

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -155,3 +155,8 @@ mac:
 
 dmg:
   title: "HaJiMi ${version}"
+
+publish:
+  provider: github
+  owner: yjz211
+  repo: HaJiMi-Math-Model-Agent

--- a/lib/desktop-packages-workflow.test.mjs
+++ b/lib/desktop-packages-workflow.test.mjs
@@ -10,15 +10,14 @@ const workflow = readFileSync(
   "utf8",
 ).replace(/\r\n/g, "\n");
 
-test("desktop package workflow builds three hosts on v* tags", () => {
+test("desktop package workflow releases Windows and retains manual cross-platform builds", () => {
   assert.match(workflow, /^name: Desktop packages/m);
   assert.match(workflow, /tags:\n\s+- "v\*"/);
   assert.match(workflow, /workflow_dispatch:/);
-  assert.match(workflow, /runner: windows-latest/);
-  assert.match(workflow, /runner: ubuntu-latest/);
-  assert.match(workflow, /runner: macos-latest/);
-  assert.match(workflow, /dist_script: dist\n/);
-  assert.match(workflow, /dist_script: dist:mac/);
+  const matrix = workflow.match(/fromJSON\(github.event_name == 'push' && '([^']+)' \|\| '([^']+)'\)/);
+  assert.ok(matrix);
+  assert.deepEqual(JSON.parse(matrix[1]), [{ pack_id: "windows", runner: "windows-latest", dist_script: "dist" }]);
+  assert.deepEqual(JSON.parse(matrix[2]).map(item => item.pack_id), ["windows", "linux", "macos"]);
   assert.match(workflow, /npm run \$\{\{ matrix\.dist_script \}\}/);
   assert.doesNotMatch(workflow, /npm run release/);
   assert.match(workflow, /CSC_IDENTITY_AUTO_DISCOVERY: "false"/);
@@ -28,6 +27,8 @@ test("desktop package workflow builds three hosts on v* tags", () => {
 test("desktop package workflow uploads GitHub Release assets only on tags", () => {
   assert.match(workflow, /if: startsWith\(github\.ref, 'refs\/tags\/v'\)/);
   assert.match(workflow, /gh release upload/);
+  assert.match(workflow, /pattern: desktop-windows/);
+  assert.match(workflow, /expected 3 Windows release assets/);
   assert.match(workflow, /permissions:\n\s+contents: write/);
   assert.match(workflow, /latest-linux\.yml/);
   assert.match(workflow, /latest-mac\.yml/);

--- a/scripts/prune-packaged-esbuild.mjs
+++ b/scripts/prune-packaged-esbuild.mjs
@@ -1,8 +1,15 @@
 import { readdir, realpath, readFile, stat, rm } from 'node:fs/promises';
 import { join, relative, isAbsolute, basename } from 'node:path';
 
+import { dereferenceSymlinks } from './dereference-standalone-symlinks.mjs';
+
 // Only trim the assembled Windows x64 app; never change development dependencies.
 export default async function prunePackagedEsbuild(context) {
+  if (context.electronPlatformName === 'darwin') {
+    const root = join(context.appOutDir, `${context.packager.appInfo.productFilename}.app`, 'Contents', 'Resources', 'standalone');
+    console.log('Materialized packaged macOS links:', dereferenceSymlinks(root));
+    return;
+  }
   if (context.electronPlatformName !== 'win32' || context.arch !== 1) return; // electron-builder Arch.x64 = 1
   const root = await realpath(join(context.appOutDir, 'resources', 'standalone'));
   const scopes = [];

--- a/scripts/prune-packaged-esbuild.test.mjs
+++ b/scripts/prune-packaged-esbuild.test.mjs
@@ -16,7 +16,7 @@ test('Windows x64 packaging retains native esbuild in both dependency layouts', 
       await writeFile(join(dir, 'esbuild.exe'), 'fixture');
     }
     const context = { appOutDir: root, electronPlatformName: 'win32', arch: 1 };
-    await prune({ ...context, electronPlatformName: 'darwin' });
+    await prune({ ...context, electronPlatformName: 'darwin', packager: { appInfo: { productFilename: 'HaJiMi' } } });
     await prune({ ...context, arch: 3 });
     assert.equal((await readdir(join(root, 'resources/standalone', scopes[0]))).length, 3);
     await prune(context);

--- a/scripts/smoke-packaged-standalone.mjs
+++ b/scripts/smoke-packaged-standalone.mjs
@@ -68,6 +68,15 @@ const parity = spawnSync(
   [join(scriptsDir, "check-hajimi-resource-parity.mjs"), projectRoot, packagedOutput.productRoot],
   { cwd: projectRoot, stdio: "inherit", windowsHide: true },
 );
+if (process.platform === "win32") {
+  if (!existsSync(join(packagedOutput.productRoot, "runtime", "windows", "drawio", "draw.io.exe"))) {
+    throw new Error("Packaged draw.io executable missing");
+  }
+  const runtime = spawnSync(process.execPath, [join(scriptsDir, "check-windows-runtime.mjs"), "--product-root", packagedOutput.productRoot], {
+    cwd: projectRoot, stdio: "inherit", windowsHide: true,
+  });
+  if (runtime.error || runtime.status !== 0) throw new Error("Packaged Windows runtime verification failed");
+}
 if (parity.error || parity.status !== 0) {
   console.error(`smoke-packaged-standalone: resource parity failed${parity.error ? `: ${parity.error.message}` : ""}`);
   process.exit(1);


### PR DESCRIPTION
修复 v0.1.1 Windows 发布：补入与本地一致的 draw.io 28.2.5 并校验官方 SHA256；直接验证成品内的 draw.io、离线运行环境及工作流资源；明确 GitHub 更新源并修正附件名称。

按用户确认，本次正式 tag 发布仅包含 Windows 安装包、blockmap 和 latest.yml。Linux/macOS 尚无原生建模后端，手动工作流保留诊断构建；macOS 符号链接问题已修复，但仍有 esbuild Universal 合包问题，未作为可用成品发布。

验证：12 项现有打包测试通过；Windows 实际安装包构建和 smoke 检查通过；本地下载安装包并验证 SHA512 一致。Linux 构建成功但不发布。发布说明明确 Windows 支持范围。