### PR TITLE
fix: remove duplicate runtime from v0.1.2 installer

### DIFF
--- a/compatibility/v010/lib/hajimi/managed-runtime.mjs
+++ b/compatibility/v010/lib/hajimi/managed-runtime.mjs
@@ -2,7 +2,7 @@ import { createHash, randomUUID, verify as verifySignature } from 'node:crypto';
 import { release as osRelease } from 'node:os';
 import { createReadStream } from 'node:fs';
 import { lstat, mkdir, open, readdir, rename, rm, stat } from 'node:fs/promises';
-import { dirname, isAbsolute, join, resolve } from 'node:path';
+import { basename, dirname, isAbsolute, join, resolve } from 'node:path';
 import { safeArchivePath, validateFiles, LIMITS, extractRuntimeArchive } from './runtime-archive.mjs';
 import { acquireInstallLock, checkedHelper, executionEnvironment, runInJob } from './runtime-process.mjs';
 
@@ -202,12 +202,17 @@ export async function runtimeStatus(productRoot, verifyFiles = false) {
     return { status: e.code === 'UNCONFIGURED' ? 'unconfigured' : e.code === 'ENOENT' ? 'missing' : 'corrupt', error: String(e.message), lastOperation: config ? states.get(config.home) ?? null : null };
   }
 }
-async function archiveSource(config, release, trust, signal) {
+export async function archiveSource(config, release, trust, signal) {
   const a = release.manifest.archive, cached = join(config.cache, a.sha256 + '.tar.gz');
   async function valid(path) { try { const s = await lstat(path); return s.isFile() && !s.isSymbolicLink() && s.size === a.size && await hashFile(path) === a.sha256; } catch (e) { if (e.code === 'ENOENT') return false; throw e; } }
   if (await valid(cached)) return cached;
   const offline = join(config.productRoot, 'runtime', 'windows', 'payloads', a.file);
   if (await valid(offline)) return offline;
+  // Compatibility workflows share the identical signed archive shipped by the product.
+  if (basename(config.productRoot) === 'v010' && basename(dirname(config.productRoot)) === 'compatibility') {
+    const shared = join(dirname(dirname(config.productRoot)), 'runtime', 'windows', 'payloads', a.file);
+    if (await valid(shared)) return shared;
+  }
   if (!a.url) throw new Error('No valid offline payload and no published download URL');
   let url = allowedUrl(a.url, trust.downloadOrigins); let response;
   for (let redirects = 0; redirects <= 4; redirects++) {

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -21,6 +21,7 @@ extraResources:
       - "bundled/**/*"
       - "toolkit/**/*"
       - "runtime/**/*"
+      - "!runtime/windows/payloads/**/*"
       - "!**/__pycache__/**/*"
   - from: bundled
     to: hajimi/bundled

--- a/lib/hajimi/managed-runtime.mjs
+++ b/lib/hajimi/managed-runtime.mjs
@@ -2,7 +2,7 @@ import { createHash, randomUUID, verify as verifySignature } from 'node:crypto';
 import { release as osRelease } from 'node:os';
 import { createReadStream } from 'node:fs';
 import { lstat, mkdir, open, readdir, rename, rm, stat } from 'node:fs/promises';
-import { dirname, isAbsolute, join, resolve } from 'node:path';
+import { basename, dirname, isAbsolute, join, resolve } from 'node:path';
 import { safeArchivePath, validateFiles, LIMITS, extractRuntimeArchive } from './runtime-archive.mjs';
 import { acquireInstallLock, checkedHelper, executionEnvironment, runInJob } from './runtime-process.mjs';
 
@@ -202,12 +202,17 @@ export async function runtimeStatus(productRoot, verifyFiles = false) {
     return { status: e.code === 'UNCONFIGURED' ? 'unconfigured' : e.code === 'ENOENT' ? 'missing' : 'corrupt', error: String(e.message), lastOperation: config ? states.get(config.home) ?? null : null };
   }
 }
-async function archiveSource(config, release, trust, signal) {
+export async function archiveSource(config, release, trust, signal) {
   const a = release.manifest.archive, cached = join(config.cache, a.sha256 + '.tar.gz');
   async function valid(path) { try { const s = await lstat(path); return s.isFile() && !s.isSymbolicLink() && s.size === a.size && await hashFile(path) === a.sha256; } catch (e) { if (e.code === 'ENOENT') return false; throw e; } }
   if (await valid(cached)) return cached;
   const offline = join(config.productRoot, 'runtime', 'windows', 'payloads', a.file);
   if (await valid(offline)) return offline;
+  // Compatibility workflows share the identical signed archive shipped by the product.
+  if (basename(config.productRoot) === 'v010' && basename(dirname(config.productRoot)) === 'compatibility') {
+    const shared = join(dirname(dirname(config.productRoot)), 'runtime', 'windows', 'payloads', a.file);
+    if (await valid(shared)) return shared;
+  }
   if (!a.url) throw new Error('No valid offline payload and no published download URL');
   let url = allowedUrl(a.url, trust.downloadOrigins); let response;
   for (let redirects = 0; redirects <= 4; redirects++) {

--- a/lib/hajimi/runtime-offline-source.test.mjs
+++ b/lib/hajimi/runtime-offline-source.test.mjs
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createHash } from 'node:crypto';
+import { mkdtemp, mkdir, writeFile, rm, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { archiveSource } from './managed-runtime.mjs';
+import { archiveSource as originalArchiveSource } from '../../compatibility/v010/lib/hajimi/managed-runtime.mjs';
+
+for (const [name, source] of [['current', archiveSource], ['original', originalArchiveSource]]) {
+  test(`${name} workflow shares only a size-and-hash-verified product archive`, async () => {
+    const root = await mkdtemp(join(tmpdir(), 'hajimi-offline-'));
+    try {
+      const payload = Buffer.from('signed archive test fixture');
+      const archive = { file: 'runtime.tar.gz', size: payload.length, sha256: createHash('sha256').update(payload).digest('hex') };
+      const shared = join(root, 'runtime/windows/payloads', archive.file);
+      await mkdir(join(root, 'runtime/windows/payloads'), { recursive: true });
+      await writeFile(shared, payload);
+      const config = { productRoot: join(root, 'compatibility/v010'), cache: join(root, 'cache') };
+      assert.equal(await source(config, { manifest: { archive } }, {}), shared);
+      await writeFile(shared, Buffer.alloc(payload.length));
+      await assert.rejects(source(config, { manifest: { archive } }, {}), /No valid offline payload/);
+      await writeFile(shared, payload);
+      await assert.rejects(source({ ...config, productRoot: join(root, 'other/v010') }, { manifest: { archive } }, {}), /No valid offline payload/);
+    } finally { await rm(root, { recursive: true, force: true }); }
+  });
+}
+
+test('installer omits the redundant compatibility archive', async () => {
+  const config = await readFile(new URL('../../electron-builder.yml', import.meta.url), 'utf8');
+  const compatibility = config.slice(config.indexOf('  - from: compatibility/v010'), config.indexOf('  - from: bundled'));
+  assert.ok(compatibility.includes('"!runtime/windows/payloads/**/*"'));
+  assert.ok(config.includes('"windows/payloads/*.tar.gz"'));
+});


### PR DESCRIPTION
v0.1.2 的 NSIS 构建因重复嵌入相同的 1.09 GB 离线运行时失败。安装包现在只在主资源目录保留一份归档，0.1.0 兼容运行时在本地归档缺失时读取该共享归档，并继续严格校验已签名清单中的大小和 SHA256；其他路径不允许使用此回退。

不修改绘图源码、配色或提示词。新增两份运行时实现的共享归档和篡改拒绝测试，以及安装配置回归测试；14 项相关测试、Lint 和类型检查通过。当前 v0.1.2 尚未发布安装包，合并并通过 CI 后会将未完成的标签移至修复提交重跑发布。